### PR TITLE
TypeScript への移行

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,14 +129,14 @@ fetch('http://localhost:3000/api/tagawa/garbage?date=2025-06-25&details=true')
 このAPIは将来的な拡張を考慮して設計されています。現在は以下の拡張が可能です：
 
 1. `details=true` パラメータを追加することで、ごみ種別の詳細情報（説明や例）を取得できます
-2. 新しいごみ種別や収集日程の追加は `garbage_data.js` ファイルを編集するだけで対応可能です
+2. 新しいごみ種別や収集日程の追加は `garbage_data.ts` ファイルを編集するだけで対応可能です
 3. 他の地区のデータを追加する場合は、同様のデータ構造で新しいファイルを作成し、APIエンドポイントを追加することで対応できます
 
 ## ファイル構成
 
 - `api/` - APIソースコード
-  - `index.js` - メインのAPIサーバーコード
-  - `garbage_data.js` - ごみ収集日程データ
+  - `index.ts` - メインのAPIサーバーコード
+  - `garbage_data.ts` - ごみ収集日程データ
   - `package.json` - 依存パッケージ情報
 - `docker-compose.yml` - Docker Compose設定ファイル
 - `README.md` - 本ドキュメント

--- a/api/garbage_data.ts
+++ b/api/garbage_data.ts
@@ -4,7 +4,13 @@
  */
 
 // ごみ種別の定義
-export const GARBAGE_TYPES = {
+export interface GarbageType {
+  name: string;
+  description: string;
+  examples: string[];
+}
+
+export const GARBAGE_TYPES: Record<string, GarbageType> = {
   "可": {
     name: "可燃ごみ",
     description: "可燃ごみ（毎週 月・木曜日）",
@@ -461,7 +467,7 @@ const schedule2026_03 = {
 };
 
 // 全スケジュールをマージ
-export const garbageSchedule = {
+export const garbageSchedule: Record<string, string[]> = {
   ...schedule2025_04,
   ...schedule2025_05,
   ...schedule2025_06,

--- a/api/index.ts
+++ b/api/index.ts
@@ -3,16 +3,27 @@ import { Hono } from 'hono'
 import { logger } from 'hono/logger'
 import { prettyJSON } from 'hono/pretty-json'
 
-// ごみ収集データをインポート
 import { GARBAGE_TYPES, garbageSchedule } from './garbage_data.js'
+
+interface GarbageDetail {
+  code: string
+  name: string
+  description: string
+  examples: string[]
+}
+
+interface GarbageResponse {
+  date: string
+  garbage_types: string[]
+  area: string
+  details?: GarbageDetail[]
+}
 
 const app = new Hono()
 
-// ミドルウェアの設定
 app.use('*', logger())
 app.use('*', prettyJSON())
 
-// ルートエンドポイント
 app.get('/', (c) => {
   return c.json({
     message: '松本市田川地区ごみ収集日程API',
@@ -22,51 +33,41 @@ app.get('/', (c) => {
   })
 })
 
-// ごみ収集日程API
 app.get('/api/tagawa/garbage', (c) => {
-  // クエリパラメータから日付を取得
   const dateParam = c.req.query('date')
-  
-  // 日付パラメータのバリデーション
+
   if (!dateParam) {
     return c.json({ error: '日付パラメータが必要です（例: date=2025-06-02）' }, 400)
   }
-  
-  // 日付形式のバリデーション（YYYY-MM-DD）
+
   const dateRegex = /^\d{4}-\d{2}-\d{2}$/
   if (!dateRegex.test(dateParam)) {
     return c.json({ error: '日付形式が無効です。YYYY-MM-DD形式で指定してください。' }, 400)
   }
-  
-  // 指定された日付のごみ種別を取得
+
   const garbageTypeCodes = garbageSchedule[dateParam] || []
-  
-  // ごみ種別コードから名称に変換
   const garbageTypeNames = garbageTypeCodes.map(code => GARBAGE_TYPES[code]?.name || code)
-  
-  // レスポンスの作成
-  const response = {
+
+  const response: GarbageResponse = {
     date: dateParam,
     garbage_types: garbageTypeNames,
     area: 'tagawa'
   }
-  
-  // 詳細情報を含めるオプション（将来的な拡張用）
+
   const includeDetails = c.req.query('details') === 'true'
-  
+
   if (includeDetails) {
     response.details = garbageTypeCodes.map(code => ({
-      code: code,
+      code,
       name: GARBAGE_TYPES[code]?.name || code,
       description: GARBAGE_TYPES[code]?.description || '',
       examples: GARBAGE_TYPES[code]?.examples || []
     }))
   }
-  
+
   return c.json(response)
 })
 
-// サーバー起動
 const port = 3000
 console.log(`Server is running on port ${port}`)
 

--- a/api/package.json
+++ b/api/package.json
@@ -1,17 +1,19 @@
 {
   "type": "module",
   "scripts": {
-    "start": "node index.js"
+    "start": "ts-node-esm index.ts"
   },
   "name": "api",
   "version": "1.0.0",
-  "main": "index.js",
+  "main": "index.ts",
   "keywords": [],
   "author": "",
   "license": "ISC",
   "description": "松本市田川地区ごみ収集日程API",
   "dependencies": {
     "@hono/node-server": "^1.14.2",
-    "hono": "^4.7.10"
+    "hono": "^4.7.10",
+    "typescript": "^5.4.0",
+    "ts-node": "^10.9.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## 概要
既存の JavaScript コードを TypeScript へ書き換えました。

## 主な変更点
- API ソースを `index.ts` と `garbage_data.ts` に移行
- `tsconfig.json` を追加
- 起動スクリプトを `ts-node-esm` で実行するよう `package.json` を更新
- README の該当箇所を TypeScript 版に修正

## テスト
- `npm start` は依存パッケージ未インストールのため実行できませんでした
  - ネットワーク制限により依存パッケージを取得できないため
